### PR TITLE
Make item names mandatory

### DIFF
--- a/src/Api/Entity/PaymentFactory.php
+++ b/src/Api/Entity/PaymentFactory.php
@@ -116,6 +116,11 @@ class PaymentFactory
 
         // ### ITEMS
         foreach ($data['items'] as $param) {
+            if (!isset($param['name']) || !$param['name']) {
+                if ($validators[self::V_SCHEME] === TRUE) {
+                    throw new ValidationException('Item\'s name can\'t be empty or null.');
+                }
+            }
             $item = new Item;
             self::map($item, [
                 'name' => 'name',

--- a/tests/cases/unit/Api/Entity/PaymentFactory.phpt
+++ b/tests/cases/unit/Api/Entity/PaymentFactory.phpt
@@ -90,8 +90,8 @@ test(function () {
         'order_number' => 3,
         'order_description' => 4,
         'items' => [
-            ['amount' => 50, 'count' => 2],
-            ['amount' => 50]
+            ['name' => 'Item 01', 'amount' => 50, 'count' => 2],
+            ['name' => 'Item 01', 'amount' => 50]
         ],
         'return_url' => 6,
         'notify_url' => 7,
@@ -100,6 +100,25 @@ test(function () {
     Assert::throws(function () use ($data) {
         PaymentFactory::create($data);
     }, ValidationException::class, '%a% (200) %a% (150) %a%');
+});
+
+// Validate items name
+test(function () {
+    $data = [
+        'amount' => 200,
+        'currency' => 2,
+        'order_number' => 3,
+        'order_description' => 4,
+        'items' => [
+            ['amount' => 50]
+        ],
+        'return_url' => 6,
+        'notify_url' => 7,
+    ];
+
+    Assert::throws(function () use ($data) {
+        PaymentFactory::create($data);
+    }, ValidationException::class, "Item's name can't be empty or null.");
 });
 
 // Turn off validators
@@ -111,8 +130,8 @@ test(function () {
         'order_number' => 3,
         'order_description' => 4,
         'items' => [
-            ['amount' => 50],
-            ['amount' => 50]
+            ['name' => 'Item 01', 'amount' => 50],
+            ['name' => 'Item 02', 'amount' => 50]
         ],
         'return_url' => 6,
         'notify_url' => 7,


### PR DESCRIPTION
I think that items name should be mandatory, because when I want to send order item without name (just with price) I always get:

![snimek obrazovky 2016-04-19 v 19 41 32](https://cloud.githubusercontent.com/assets/374917/14653209/2de04bf4-0678-11e6-9b1f-876114b002ac.png)
