### PR TITLE
Tests: added failing test on EET item with no VAT

### DIFF
--- a/tests/cases/unit/Api/Entity/PaymentFactory.phpt
+++ b/tests/cases/unit/Api/Entity/PaymentFactory.phpt
@@ -256,3 +256,30 @@ test(function () {
 		Assert::fail('EET sum and EET tax should be equal');
 	}
 });
+
+// Validate EET sum and order sum (item without VAT)
+test(function () {
+	$data = [
+		'amount' => 274.0,
+		'currency' => 2,
+		'order_number' => 3,
+		'order_description' => 4,
+		'items' => [
+			['name' => 'x', 'amount' => 274.0],
+		],
+		'return_url' => 6,
+		'notify_url' => 7,
+		'eet' => [
+			'celk_trzba' => 174.0,
+			'zakl_nepodl_dph' => 100.0,
+			'zakl_dan1' => 143.80165289256,
+			'dan1' => 30.198347107438,
+		],
+	];
+
+	try {
+		PaymentFactory::create($data);
+	} catch (ValidationException $e) {
+		Assert::fail('EET sum and EET tax should be equal with item with no VAT');
+	}
+});


### PR DESCRIPTION
GoPay [EET](https://doc.gopay.com/cs/?shell#eet) object can use property `zakl_nepodl_dph`, but we don't use this property, we just dump it and validation in `PaymentFactory::create()` fails, because of numbers are different...

I think this test souhld pass, but not sure how to fix it. 