### PR TITLE
Fix: EET validation `zakl_nepodl_dph`

### DIFF
--- a/src/Api/Entity/PaymentFactory.php
+++ b/src/Api/Entity/PaymentFactory.php
@@ -178,8 +178,8 @@ class PaymentFactory
 			], $data['eet']);
 
 			$eetSum = $eet->getSum();
-			$eetTotal = $eet->calcTotal();
-			$eetTaxSum = $eet->getTax()
+			$eetTotal = $eet->getTax()
+				+ $eet->getTaxBaseNoVat()
 				+ $eet->getTaxBase()
 				+ $eet->getTaxBaseReducedRateFirst()
 				+ $eet->getTaxReducedRateFirst()
@@ -187,11 +187,11 @@ class PaymentFactory
 				+ $eet->getTaxReducedRateSecond();
 
 			if ($validators[self::V_PRICES] === TRUE) {
-				if (number_format($eetSum, 8) !== number_format($eetTaxSum, 8)) {
-					throw new ValidationException(sprintf('EET sum (%s) and EET tax sum (%s) do not match', $eetSum, $eetTaxSum));
+				if (number_format($eetSum, 8) !== number_format($eetTotal, 8)) {
+					throw new ValidationException(sprintf('EET sum (%s) and EET tax sum (%s) do not match', $eetSum, $eetTotal));
 				}
 
-				if (number_format($eetTotal, 8) !== number_format($orderPrice, 8)) {
+				if (number_format($eetSum, 8) !== number_format($orderPrice, 8)) {
 					throw new ValidationException(sprintf('EET sum (%s) and order sum (%s) do not match', $eetSum, $orderPrice));
 				}
 			}

--- a/src/Api/Objects/Eet.php
+++ b/src/Api/Objects/Eet.php
@@ -248,20 +248,6 @@ class Eet extends AbstractObject
 	 */
 
 	/**
-	 * @return float
-	 */
-	public function calcTotal()
-	{
-		$sum = $this->getSum();
-
-		if ($this->getTaxBaseNoVat()) {
-			$sum += $this->getTaxBaseNoVat();
-		}
-
-		return $sum;
-	}
-
-	/**
 	 * ABSTRACT ****************************************************************
 	 */
 

--- a/tests/cases/unit/Api/Entity/PaymentFactory.phpt
+++ b/tests/cases/unit/Api/Entity/PaymentFactory.phpt
@@ -270,7 +270,7 @@ test(function () {
 		'return_url' => 6,
 		'notify_url' => 7,
 		'eet' => [
-			'celk_trzba' => 174.0,
+			'celk_trzba' => 274.0,
 			'zakl_nepodl_dph' => 100.0,
 			'zakl_dan1' => 143.80165289256,
 			'dan1' => 30.198347107438,


### PR DESCRIPTION
I'm triing to fix error `EET sum (X) and EET tax sum (Y) do not match`, when using EET with items without VAT (`zakl_nepodl_dph`). 

Note: I had error in my last PR #30... there was typo in eet_sum (`celk_trzba`). I'm so sorry.