### PR TITLE
Improve HttpException::format() method

### DIFF
--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -14,11 +14,12 @@ class HttpException extends GopayException
 	public static function format(stdClass $error)
 	{
 		$field = isset($error->field) ? '[' . $error->field . ']' : NULL;
-		$message = isset($error->message) ? $error->message : (isset($error->description) ? $error->description : NULL);
+		$description = isset($error->description) ? $error->description : NULL;
+		$message = isset($error->message) ? rtrim($error->message, '.') . ($description !== NULL ? ':' : '') : NULL;
 		$scope = isset($error->scope) ? '(' . $error->scope . ')' : NULL;
 		$code = isset($error->error_code) ? '#' . $error->error_code : NULL;
 
-		$parts = array_filter([$code, $scope, $field, $message], function ($item) {
+		$parts = array_filter([$code, $scope, $field, $message, $description], function ($item) {
 			return $item !== NULL;
 		});
 

--- a/tests/cases/unit/Exception/HttpException.phpt
+++ b/tests/cases/unit/Exception/HttpException.phpt
@@ -52,3 +52,16 @@ test(function () {
 
 	Assert::equal('#400 (validation) Invalid field long', HttpException::format($error));
 });
+
+// With message and description
+test(function () {
+	$error = (object) [
+		'scope' => 'G',
+		'error_code' => 111,
+		'error_name' => 'INVALID',
+		'message' => 'Wrong value.',
+		'description' => 'eshop with goId=1234567890 was not found',
+	];
+
+	Assert::equal('#111 (G) Wrong value: eshop with goId=1234567890 was not found', HttpException::format($error));
+});


### PR DESCRIPTION
When you get following error response, it will just log `#111 (G) Wrong value.`, so you don`t know what is actually wrong: 

```json
{
    "date_issued": "2017-07-14T15:23:28.691+0200",
    "errors": [
        {
            "scope": "G",
            "error_code": 111,
            "error_name": "INVALID",
            "message": "Wrong value.",
            "description": "eshop with goId=1234567890 was not found"
        }
    ]
}
```

This little improvement makes logged errors more clearer, so next time you will get this:
```
#111 (G) Wrong value: eshop with goId=1234567890 was not found
```