### PR TITLE
BankExpressTransfer: UniCredit CZ now supported

### DIFF
--- a/src/Api/Lists/SwiftCode.php
+++ b/src/Api/Lists/SwiftCode.php
@@ -11,6 +11,7 @@ class SwiftCode
 	const MBANK = 'BREXCZPP';
 	const FIO_BANKA = 'FIOBCZPP';
 	const CSOB = 'CEKOCZPP';
+	const UNICREDIT_BANK_CZ = 'BACXCZPP';
 	const ERA = 'CEKOCZPP-ERA';
 	const VSEOBECNA_VEROVA_BANKA_BANKA = 'SUBASKBX';
 	const TATRA_BANKA = 'TATRSKBX';
@@ -42,6 +43,7 @@ class SwiftCode
 			self::FIO_BANKA,
 			self::CSOB,
 			self::ERA,
+			self::UNICREDIT_BANK_CZ,
 		];
 	}
 

--- a/tests/cases/unit/Api/Lists/SwiftCode.phpt
+++ b/tests/cases/unit/Api/Lists/SwiftCode.phpt
@@ -11,12 +11,12 @@ require __DIR__ . '/../../../../bootstrap.php';
 
 // All
 test(function () {
-	Assert::count(15, SwiftCode::all());
+	Assert::count(16, SwiftCode::all());
 });
 
 // CZ
 test(function () {
-	Assert::count(7, SwiftCode::cz());
+	Assert::count(8, SwiftCode::cz());
 });
 
 // SK


### PR DESCRIPTION
Gopay pridalo podporu pro Expresni prevod UniCredit Bank https://www.gopay.com/www/cs/platebni-metody.html